### PR TITLE
perf: reduce peak memory usage by ~12 MB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["icons", "gui", "freedesktop"]
 
 [dependencies]
 dirs = "5.0.1"
-rust-ini = "0.20.0"
 thiserror = "1.0.56"
 once_cell = "1.19.0"
 xdg = "2.5.2"
 tracing = "0.1.41"
+ini_core = "0.2.0"
 
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/src/theme/directories.rs
+++ b/src/theme/directories.rs
@@ -3,7 +3,7 @@ pub struct Directory<'a> {
     pub name: &'a str,
     pub size: i16,
     pub scale: i16,
-    pub context: Option<&'a str>,
+    // pub context: Option<&'a str>,
     pub type_: DirectoryType,
     pub maxsize: i16,
     pub minsize: i16,

--- a/src/theme/error.rs
+++ b/src/theme/error.rs
@@ -8,6 +8,4 @@ pub(crate) enum ThemeError {
     ThemeIndexNotFound(PathBuf),
     #[error("IoError: {0}")]
     IoError(#[from] io::Error),
-    #[error("IniError: {0}")]
-    IniError(#[from] ini::Error),
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,10 +1,8 @@
 use crate::theme::error::ThemeError;
 use crate::theme::paths::ThemePath;
-use ini::Ini;
 use once_cell::sync::Lazy;
 pub(crate) use paths::BASE_PATHS;
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 
 mod directories;
@@ -16,9 +14,14 @@ type Result<T> = std::result::Result<T, ThemeError>;
 
 pub static THEMES: Lazy<BTreeMap<String, Vec<Theme>>> = Lazy::new(get_all_themes);
 
+pub fn read_ini_theme(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+#[derive(Debug)]
 pub struct Theme {
     pub path: ThemePath,
-    pub index: Ini,
+    pub index: PathBuf,
 }
 
 impl Theme {
@@ -29,23 +32,30 @@ impl Theme {
         scale: u16,
         force_svg: bool,
     ) -> Option<PathBuf> {
-        self.try_get_icon_exact_size(name, size, scale, force_svg)
-            .or_else(|| self.try_get_icon_closest_size(name, size, scale, force_svg))
+        let file = read_ini_theme(&self.index).unwrap_or_default();
+        self.try_get_icon_exact_size(file.as_str(), name, size, scale, force_svg)
+            .or_else(|| self.try_get_icon_closest_size(file.as_str(), name, size, scale, force_svg))
     }
 
     fn try_get_icon_exact_size(
         &self,
+        file: &str,
         name: &str,
         size: u16,
         scale: u16,
         force_svg: bool,
     ) -> Option<PathBuf> {
-        self.match_size(size, scale)
+        self.match_size(file, size, scale)
             .find_map(|path| try_build_icon_path(name, path, force_svg))
     }
 
-    fn match_size(&self, size: u16, scale: u16) -> impl Iterator<Item = PathBuf> + '_ {
-        let dirs = self.get_all_directories();
+    fn match_size<'a>(
+        &'a self,
+        file: &'a str,
+        size: u16,
+        scale: u16,
+    ) -> impl Iterator<Item = PathBuf> + 'a {
+        let dirs = self.get_all_directories(file);
 
         dirs.filter(move |directory| directory.match_size(size, scale))
             .map(|dir| dir.name)
@@ -54,18 +64,19 @@ impl Theme {
 
     fn try_get_icon_closest_size(
         &self,
+        file: &str,
         name: &str,
         size: u16,
         scale: u16,
         force_svg: bool,
     ) -> Option<PathBuf> {
-        self.closest_match_size(size, scale)
+        self.closest_match_size(file, size, scale)
             .iter()
             .find_map(|path| try_build_icon_path(name, path, force_svg))
     }
 
-    fn closest_match_size(&self, size: u16, scale: u16) -> Vec<PathBuf> {
-        let dirs = self.get_all_directories();
+    fn closest_match_size(&self, file: &str, size: u16, scale: u16) -> Vec<PathBuf> {
+        let dirs = self.get_all_directories(file);
 
         let mut dirs: Vec<_> = dirs
             .filter_map(|directory| {
@@ -181,7 +192,7 @@ pub(super) fn get_all_themes() -> BTreeMap<String, Vec<Theme>> {
 }
 
 impl Theme {
-    pub(crate) fn from_path<P: AsRef<Path>>(path: P, index: Option<&Ini>) -> Option<Self> {
+    pub(crate) fn from_path<P: AsRef<Path>>(path: P, index: Option<&PathBuf>) -> Option<Self> {
         let path = path.as_ref();
 
         let has_index = path.join("index.theme").exists() || index.is_some();
@@ -203,15 +214,6 @@ impl Theme {
     }
 }
 
-impl Debug for Theme {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut content = vec![];
-        self.index.write_to(&mut content).expect("Write error");
-        let content = String::from_utf8_lossy(&content);
-        writeln!(f, "ThemeIndex{{path: {:?}, index: {content:?}}}", self.path)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::THEMES;
@@ -223,21 +225,20 @@ mod test {
         let themes = THEMES.get("Adwaita").unwrap();
         println!(
             "{:?}",
-            themes.iter().find_map(|t| t.try_get_icon_exact_size(
-                "edit-delete-symbolic",
-                24,
-                1,
-                false
-            ))
+            themes.iter().find_map(|t| {
+                let file = crate::theme::read_ini_theme(&t.index).unwrap_or_default();
+                t.try_get_icon_exact_size(file.as_str(), "edit-delete-symbolic", 24, 1, false)
+            })
         );
     }
 
     #[test]
     fn should_get_png_first() {
         let themes = THEMES.get("hicolor").unwrap();
-        let icon = themes
-            .iter()
-            .find_map(|t| t.try_get_icon_exact_size("blueman", 24, 1, true));
+        let icon = themes.iter().find_map(|t| {
+            let file = crate::theme::read_ini_theme(&t.index).unwrap_or_default();
+            t.try_get_icon_exact_size(file.as_str(), "blueman", 24, 1, true)
+        });
         assert_that!(icon).is_some().is_equal_to(PathBuf::from(
             "/usr/share/icons/hicolor/scalable/apps/blueman.svg",
         ));
@@ -246,9 +247,10 @@ mod test {
     #[test]
     fn should_get_svg_first() {
         let themes = THEMES.get("hicolor").unwrap();
-        let icon = themes
-            .iter()
-            .find_map(|t| t.try_get_icon_exact_size("blueman", 24, 1, false));
+        let icon = themes.iter().find_map(|t| {
+            let file = crate::theme::read_ini_theme(&t.index).unwrap_or_default();
+            t.try_get_icon_exact_size(file.as_str(), "blueman", 24, 1, false)
+        });
         assert_that!(icon).is_some().is_equal_to(PathBuf::from(
             "/usr/share/icons/hicolor/22x22/apps/blueman.png",
         ));

--- a/src/theme/paths.rs
+++ b/src/theme/paths.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use dirs::home_dir;
-use ini::Ini;
 use once_cell::sync::Lazy;
 use xdg::BaseDirectories;
 
@@ -33,18 +32,18 @@ fn icon_theme_base_paths() -> Vec<PathBuf> {
     data_dirs.into_iter().filter(|p| p.exists()).collect()
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ThemePath(pub PathBuf);
 
 impl ThemePath {
-    pub(super) fn index(&self) -> theme::Result<Ini> {
+    pub(super) fn index(&self) -> theme::Result<PathBuf> {
         let index = self.0.join("index.theme");
 
         if !index.exists() {
             return Err(ThemeError::ThemeIndexNotFound(index));
         }
 
-        Ok(Ini::load_from_file(index)?)
+        Ok(index)
     }
 }
 


### PR DESCRIPTION
Switch from `rust-ini` to `ini_core`, and avoid caching the icon theme files in memory.

Peak memory usage of cosmic-settings dropped from 24.9 MB to 12.9 MB.