### PR TITLE
Migrate to Rust 2024 and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-freedesktop-icons"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 
 license = "MIT"
 description = "A Freedesktop Icons lookup crate"
@@ -10,18 +10,18 @@ readme = "README.md"
 keywords = ["icons", "gui", "freedesktop"]
 
 [dependencies]
-dirs = "5.0"
+dirs = "6.0"
 thiserror = "2.0"
-xdg = "2.5"
-tracing = "0.1.0"
+xdg = "3.0"
+tracing = "0.1.41"
 ini_core = "0.2.0"
 memmap2 = "0.9"
 
 [dev-dependencies]
-speculoos = "0.11.0"
+speculoos = "0.13.0"
 linicon = "2.3.0"
-gtk4 = "0.9"
-criterion = "0.5"
+gtk4 = "0.10"
+criterion = "0.7"
 
 [features]
 default = []

--- a/benches/simple_lookup.rs
+++ b/benches/simple_lookup.rs
@@ -1,6 +1,6 @@
 use criterion::{
-    black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
-    PlotConfiguration,
+    AxisScale, BenchmarkId, Criterion, PlotConfiguration, black_box, criterion_group,
+    criterion_main,
 };
 use freedesktop_icons::lookup;
 use gtk4::{IconLookupFlags, IconTheme, TextDirection};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@
 //! ```
 use theme::BASE_PATHS;
 
-use crate::cache::{CacheEntry, CACHE};
-use crate::theme::{try_build_icon_path, THEMES};
+use crate::cache::{CACHE, CacheEntry};
+use crate::theme::{THEMES, try_build_icon_path};
 use std::io::BufRead;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -109,7 +109,7 @@ pub fn list_themes() -> Vec<String> {
 ///
 /// ## Example
 /// ```rust, no_run
-/// use freedesktop_icons::default_theme_gtk;
+/// use cosmic_freedesktop_icons::default_theme_gtk;
 ///
 /// let theme = default_theme_gtk();
 ///
@@ -174,7 +174,7 @@ pub struct LookupBuilder<'a> {
 ///
 /// let icon = lookup("firefox").find();
 /// # }
-pub fn lookup(name: &str) -> LookupBuilder {
+pub fn lookup(name: &str) -> LookupBuilder<'_> {
     LookupBuilder::new(name)
 }
 
@@ -304,7 +304,7 @@ impl<'a> LookupBuilder<'a> {
                 CacheEntry::NotFound(last_check)
                     if last_check.duration_since(Instant::now()).as_secs() < 5 =>
                 {
-                    return None
+                    return None;
                 }
                 _ => (),
             }
@@ -412,7 +412,7 @@ impl<'a> LookupBuilder<'a> {
 #[cfg(test)]
 #[cfg(feature = "local_tests")]
 mod test {
-    use crate::{lookup, CacheEntry, CACHE};
+    use crate::{CACHE, CacheEntry, lookup};
     use speculoos::prelude::*;
     use std::path::PathBuf;
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -130,32 +130,20 @@ fn try_build_svg<P: AsRef<Path>>(name: &str, path: P) -> Option<PathBuf> {
     let path = path.as_ref();
     let svg = path.join(format!("{name}.svg"));
 
-    if svg.exists() {
-        Some(svg)
-    } else {
-        None
-    }
+    if svg.exists() { Some(svg) } else { None }
 }
 
 fn try_build_png<P: AsRef<Path>>(name: &str, path: P) -> Option<PathBuf> {
     let path = path.as_ref();
     let png = path.join(format!("{name}.png"));
 
-    if png.exists() {
-        Some(png)
-    } else {
-        None
-    }
+    if png.exists() { Some(png) } else { None }
 }
 
 fn try_build_xmp<P: AsRef<Path>>(name: &str, path: P) -> Option<PathBuf> {
     let path = path.as_ref();
     let xmp = path.join(format!("{name}.xmp"));
-    if xmp.exists() {
-        Some(xmp)
-    } else {
-        None
-    }
+    if xmp.exists() { Some(xmp) } else { None }
 }
 
 // Iter through the base paths and get all theme directories

--- a/src/theme/parse.rs
+++ b/src/theme/parse.rs
@@ -1,5 +1,5 @@
-use crate::theme::directories::{Directory, DirectoryType};
 use crate::theme::Theme;
+use crate::theme::directories::{Directory, DirectoryType};
 
 fn icon_theme_section(file: &str) -> impl Iterator<Item = (&str, &str)> + '_ {
     ini_core::Parser::new(file)
@@ -24,7 +24,7 @@ enum DirectorySection<'a> {
     Section(&'a str),
 }
 
-fn sections(file: &str) -> impl Iterator<Item = DirectorySection> {
+fn sections(file: &str) -> impl Iterator<Item = DirectorySection<'_>> {
     ini_core::Parser::new(file).filter_map(move |item| match item {
         ini_core::Item::Property(key, Some(value)) => Some(DirectorySection::Property(key, value)),
         ini_core::Item::Section(section) => Some(DirectorySection::Section(section)),

--- a/src/theme/paths.rs
+++ b/src/theme/paths.rs
@@ -11,19 +11,18 @@ pub(crate) static BASE_PATHS: LazyLock<Vec<PathBuf>> = LazyLock::new(icon_theme_
 /// Look in $HOME/.icons (for backwards compatibility), in $XDG_DATA_DIRS/icons, in $XDG_DATA_DIRS/pixmaps and in /usr/share/pixmaps (in that order).
 /// Paths that are not found are filtered out.
 fn icon_theme_base_paths() -> Vec<PathBuf> {
-    let mut data_dirs: Vec<_> = BaseDirectories::new()
-        .map(|bd| {
-            let mut data_dirs: Vec<_> = bd
-                .get_data_dirs()
-                .into_iter()
-                .flat_map(|p| [p.join("icons"), p.join("pixmaps")])
-                .collect();
-            let data_home = bd.get_data_home();
-            data_dirs.push(data_home.join("icons"));
-            data_dirs.push(data_home.join("pixmaps"));
-            data_dirs
-        })
-        .unwrap_or_default();
+    let base_dirs = BaseDirectories::new();
+    let mut data_dirs: Vec<_> = base_dirs
+        .get_data_dirs()
+        .into_iter()
+        .flat_map(|p| [p.join("icons"), p.join("pixmaps")])
+        .collect();
+
+    if let Some(data_home) = base_dirs.get_data_home() {
+        data_dirs.push(data_home.join("icons"));
+        data_dirs.push(data_home.join("pixmaps"));
+    }
+
     match home_dir().map(|home| home.join(".icons")) {
         Some(home_icon_dir) => data_dirs.push(home_icon_dir),
         None => tracing::warn!("No $HOME directory found"),
@@ -49,7 +48,7 @@ impl ThemePath {
 #[cfg(test)]
 mod test {
     use crate::theme::paths::icon_theme_base_paths;
-    use crate::theme::{get_all_themes, Theme};
+    use crate::theme::{Theme, get_all_themes};
     use speculoos::prelude::*;
 
     #[test]


### PR DESCRIPTION
Mainly to not need to pull in xdg 2.5 on other repos updated to 3.0.