### PR TITLE
fix: use elapsed() instead of inverted duration_since check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,9 +256,7 @@ impl<'a> LookupBuilder<'a> {
         if self.cache {
             match self.cache_lookup(self.theme) {
                 CacheEntry::Found(icon) => return Some(icon),
-                CacheEntry::NotFound(last_check)
-                    if last_check.duration_since(Instant::now()).as_secs() < 5 =>
-                {
+                CacheEntry::NotFound(last_check) if last_check.elapsed().as_secs() < 5 => {
                     return None;
                 }
                 _ => (),


### PR DESCRIPTION
## Summary

Fixes the cache retry logic which had an inverted time comparison, causing icons to never be found after their first cache miss.

## The Bug

In `src/lib.rs` line 259-261:
```rust
CacheEntry::NotFound(last_check)
    if last_check.duration_since(Instant::now()).as_secs() < 5 =>
{
    return None;
}
```

`duration_since` computes `self - earlier`, so `past.duration_since(future)` always returns `Duration::ZERO` (saturates to 0 in release mode). This means:
- `last_check.duration_since(Instant::now()).as_secs()` is always 0
- `0 < 5` is always true
- Therefore, once an icon is marked `NotFound`, it will **never** be retried

## The Fix

```rust
CacheEntry::NotFound(last_check) if last_check.elapsed().as_secs() < 5 => {
    return None;
}
```

Using `elapsed()` (equivalent to `Instant::now().duration_since(last_check)`) correctly measures how much time has passed since the cache entry was created.

## Impact

This bug causes newly installed applications (especially Flatpaks) to have missing icons until a full restart. The intended 5-second retry window was effectively "never retry".

## Introduced In

PR #6 (feat: resettable cache and icon retry after time)