### PR TITLE
feat: walk subdirectories under with_extra_paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use memmap2::Mmap;
 use theme::BASE_PATHS;
 
 use crate::cache::{CACHE, CacheEntry};
-use crate::theme::{THEMES, Theme, try_build_icon_path};
+use crate::theme::{THEMES, Theme, search_subtree, try_build_icon_path};
 use std::hash::{Hash, Hasher};
 use std::io::BufRead;
 use std::ops::ControlFlow;
@@ -225,8 +225,12 @@ impl<'a> LookupBuilder<'a> {
         self
     }
 
-    /// Search additional directories for the icon as flat paths (no theme hierarchy).
-    /// These paths are searched before the theme chain.
+    /// Search additional directories for the icon, before the theme chain.
+    /// Each path is checked first as a flat directory (`<path>/<name>.<ext>`,
+    /// for apps like JetBrains Toolbox that drop icons at the root) and then
+    /// walked up to 5 levels deep (for apps like Dropbox that ship a partial
+    /// `hicolor/<size>/<context>/<file>` tree). The XDG `index.theme` is not
+    /// required.
     #[inline]
     pub fn with_extra_paths<'b: 'a>(mut self, paths: &'b [PathBuf]) -> Self {
         self.extra_paths = paths;
@@ -274,29 +278,18 @@ impl<'a> LookupBuilder<'a> {
         }
 
         if !self.extra_paths.is_empty() {
-            let extensions = if self.force_svg {
-                [".svg", ".png", ".xpm"]
+            let extensions: &[&'static str] = if self.force_svg {
+                &[".svg", ".png", ".xpm"]
             } else {
-                [".png", ".svg", ".xpm"]
+                &[".png", ".svg", ".xpm"]
             };
-            let mut name_buf = String::new();
-
-            let result = extensions
-                .into_iter()
-                .try_for_each(|ext| {
-                    self.extra_paths.iter().try_for_each(|dir| {
-                        let mut path = dir.clone();
-                        if try_build_icon_path(&mut path, &mut name_buf, self.name, ext) {
-                            return ControlFlow::Break(path);
-                        }
-                        name_buf.clear();
-                        ControlFlow::Continue(())
-                    })
-                })
-                .break_value();
-
-            if result.is_some() {
-                return result;
+            const EXTRA_PATH_WALK_DEPTH: u32 = 5;
+            if let Some(found) = self
+                .extra_paths
+                .iter()
+                .find_map(|dir| search_subtree(dir, self.name, extensions, EXTRA_PATH_WALK_DEPTH))
+            {
+                return Some(found);
             }
         }
 
@@ -618,5 +611,78 @@ mod test {
             matches!(expected_cache_result, CacheEntry::NotFound(..)),
             "When lookup fails a first time, subsequent attempts should fail from cache"
         );
+    }
+
+    // Self-contained tests for `with_extra_paths`. A small Drop-guarded temp
+    // directory keeps the dev-dependency surface unchanged.
+    struct TempDir(PathBuf);
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "freedesktop-icons-test-{}-{n}-{tag}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+        fn touch(&self, rel: &str) -> PathBuf {
+            let abs = self.0.join(rel);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(&abs, b"").unwrap();
+            abs
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn extra_paths_flat() {
+        // JetBrains Toolbox: <theme_path>/toolbox-tray-color.png
+        let tmp = TempDir::new("flat");
+        let expected = tmp.touch("freedesktop-icons-test-flat.png");
+        let found = lookup("freedesktop-icons-test-flat")
+            .with_extra_paths(&[tmp.0.clone()])
+            .find();
+        assert_eq!(found.as_deref(), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn extra_paths_hicolor_tree() {
+        // Dropbox: <theme_path>/hicolor/<size>/<context>/<file>
+        let tmp = TempDir::new("hicolor");
+        let expected = tmp.touch("hicolor/16x16/status/freedesktop-icons-test-hicolor.png");
+        let found = lookup("freedesktop-icons-test-hicolor")
+            .with_extra_paths(&[tmp.0.clone()])
+            .find();
+        assert_eq!(found.as_deref(), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn extra_paths_prefer_svg_when_forced() {
+        let tmp = TempDir::new("prefer-svg");
+        tmp.touch("icons/freedesktop-icons-test-prefer.png");
+        let expected = tmp.touch("icons/freedesktop-icons-test-prefer.svg");
+        let found = lookup("freedesktop-icons-test-prefer")
+            .force_svg()
+            .with_extra_paths(&[tmp.0.clone()])
+            .find();
+        assert_eq!(found.as_deref(), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn extra_paths_miss_returns_none_without_falling_through() {
+        // Empty tree + a name unlikely to exist on the host's system themes.
+        let tmp = TempDir::new("miss");
+        let found = lookup("freedesktop-icons-test-no-such-icon-7f3a")
+            .with_extra_paths(&[tmp.0.clone()])
+            .find();
+        assert_eq!(found, None);
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -152,6 +152,46 @@ fn try_build_ext(path: &mut PathBuf, name_buf: &mut String, name: &str, ext: &'s
     path.exists()
 }
 
+// SNI's IconThemePath doesn't have to be an XDG-shaped theme. Some apps point
+// it at a flat dir (JetBrains Toolbox); others ship a partial hicolor tree
+// (Dropbox: `<theme_path>/hicolor/<size>/<context>/<file>`). To handle both,
+// walk subdirectories up to `depth` extra levels, preferring earlier
+// extensions at each level (DFS, first match wins).
+pub(super) fn search_subtree(
+    dir: &Path,
+    name: &str,
+    extensions: &[&'static str],
+    depth: u32,
+) -> Option<PathBuf> {
+    for ext in extensions {
+        let mut candidate = dir.to_path_buf();
+        candidate.push(format!("{name}{ext}"));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    if depth == 0 {
+        return None;
+    }
+    let mut subdirs: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(entries) => entries
+            .flatten()
+            .filter_map(|entry| {
+                entry
+                    .file_type()
+                    .ok()
+                    .filter(|ft| ft.is_dir())
+                    .map(|_| entry.path())
+            })
+            .collect(),
+        Err(_) => return None,
+    };
+    subdirs.sort();
+    subdirs
+        .into_iter()
+        .find_map(|sub| search_subtree(&sub, name, extensions, depth - 1))
+}
+
 // Iter through the base paths and get all theme directories
 pub(super) fn get_all_themes() -> BTreeMap<Vec<u8>, Vec<Theme>> {
     let mut icon_themes = BTreeMap::<Vec<u8>, Vec<_>>::new();


### PR DESCRIPTION
## Summary

`with_extra_paths` (added in #10) searches each path as a flat directory only — `<path>/<name>.<ext>`. That covers JetBrains Toolbox (which drops icons at the root of its `IconThemePath`), but misses apps that ship a partial XDG-shaped tree without an `index.theme` at the root.

The headline case is Dropbox:

```
<theme_path>/hicolor/16x16/status/dropboxstatus-idle.png
```

Same story for pcloud and other tray apps that lay out a `hicolor/<size>/<context>/<file>` subtree under the path advertised via the SNI `IconThemePath` D-Bus property.

After this change, each extra path is checked first as a flat directory (preserving the existing JetBrains-style fast path), then walked DFS up to 5 levels deep. Extension preference (`force_svg` order) is honored at each level, and subdirectories are visited in sorted order for determinism. The XDG `index.theme` is still not required.

## Tests

Four new self-contained unit tests in `src/lib.rs::test`, using a small `Drop`-guarded `TempDir` helper to avoid expanding the dev-dependency surface:

- `extra_paths_flat` — JetBrains-style `<path>/<name>.png`.
- `extra_paths_hicolor_tree` — Dropbox-style `<path>/hicolor/16x16/status/<name>.png`.
- `extra_paths_prefer_svg_when_forced` — verifies extension priority at a given level.
- `extra_paths_miss_returns_none_without_falling_through` — empty tree + unique name returns `None`.

The 7 pre-existing test failures in the suite (`flatpak_slack`, `vscode_pixmap`, `ubuntu_additional_drivers`, four `theme::test::should_get_*`) are host-state-dependent (require Slack flatpak, VS Code, gnome icon theme, etc.) and fail on unmodified `main` too — not from this change.

## Motivation

Surfaced while reviewing [pop-os/cosmic-applets#1409](https://github.com/pop-os/cosmic-applets/pull/1409). That PR (already approved) ships SNI `IconThemePath` plumbing in `cosmic-applet-status-area` via `icon::from_name(...).with_extra_paths(...)`, which routes here. JetBrains Toolbox resolves; Dropbox doesn't, because of the flat-only behavior. With this change, the same applet code resolves both layouts e2e.

___

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.